### PR TITLE
feat: add property level maturity + ga4gh prefix/keys in RST files

### DIFF
--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -18,8 +18,8 @@ MATURITY_MAPPING: dict[str, tuple[str, str]] = {
 
 # Mapping to corresponding code for ordered property in arrays
 ORDERED_MAPPING: dict[bool, str] = {
-    True: "OL",
-    False: "UL"
+    True: "&#8595;",
+    False: "&#8942;"
 }
 
 
@@ -120,7 +120,7 @@ def resolve_flags(class_property_attributes: dict) -> str:
             flags += f"""
                         .. raw:: html
 
-                            <span style="background-color: #{background_color}; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">{maturity_code}</span>"""
+                            <span style="background-color: #{background_color}; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;">{maturity_code}</span>"""
 
     ordered = class_property_attributes.get("ordered")
     ordered_code = ORDERED_MAPPING.get(ordered, None)
@@ -131,7 +131,7 @@ def resolve_flags(class_property_attributes: dict) -> str:
                         .. raw:: html\n"""
 
         flags += f"""
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">{ordered_code}</span>"""
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;">{ordered_code}</span>"""
     return flags
 
 

--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -117,21 +117,23 @@ def resolve_flags(class_property_attributes: dict) -> str:
     if maturity is not None:
         background_color, maturity_code = MATURITY_MAPPING.get(maturity, (None, None))
         if background_color and maturity_code:
+            title = f"{maturity.replace("_", " ").title()} Maturity Level"
             flags += f"""
                         .. raw:: html
 
-                            <span style="background-color: #{background_color}; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;">{maturity_code}</span>"""
+                            <span style="background-color: #{background_color}; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="{title}">{maturity_code}</span>"""
 
     ordered = class_property_attributes.get("ordered")
     ordered_code = ORDERED_MAPPING.get(ordered, None)
 
     if ordered_code is not None:
+        title = "Ordered" if ordered else "Unordered"
         if not flags:
             flags += """
                         .. raw:: html\n"""
 
         flags += f"""
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;">{ordered_code}</span>"""
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="{title}">{ordered_code}</span>"""
     return flags
 
 

--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -13,7 +13,7 @@ MATURITY_MAPPING: dict[str, tuple[str, str]] = {
     "draft": ("D3D3D3", "D"),
     "trial_use": ("FFFF99", "TU"),
     "normative": ("B6D7A8", "N"),
-    "deprecated": ("EA9999", "DP")
+    "deprecated": ("EA9999", "X")
 }
 
 # Mapping to corresponding code for ordered property in arrays

--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -89,7 +89,6 @@ def add_ga4gh_digest(class_definition: dict, f: TextIOWrapper) -> None:
     """
     ga4gh_digest = class_definition.get("ga4ghDigest") or {}
     if ga4gh_digest:
-        ga4gh_prefix = ga4gh_digest.get("prefix") or "None"
         print(f"""
 **GA4GH Digest**
 
@@ -102,7 +101,7 @@ def add_ga4gh_digest(class_definition: dict, f: TextIOWrapper) -> None:
     *  - Prefix
        - Keys
 
-    *  - {ga4gh_prefix}
+    *  - {ga4gh_digest.get("prefix") or "None"}
        - {str(ga4gh_digest.get("keys") or [])}\n""", file=f)
 
 
@@ -143,15 +142,15 @@ def main(proc_schema):
             if maturity == 'draft':
                 print("""
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     """, file=f)
             elif maturity == 'trial use':
                 print("""
 .. note:: This data class is at a **trial use** maturity level and may change
     in future releases. Maturity levels are described in the :ref:`maturity-model`.
-                      
+
                     """, file=f)
             print("**Computational Definition**\n", file=f)
             print(class_definition['description'], file=f)

--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -89,10 +89,8 @@ def add_ga4gh_digest(class_definition: dict, f: TextIOWrapper) -> None:
     """
     ga4gh_digest = class_definition.get("ga4ghDigest") or {}
     if ga4gh_digest:
-        ga4gh_prefix = ga4gh_digest.get("prefix") or ""
-        ga4gh_keys = ga4gh_digest.get("keys") or []
-        if ga4gh_prefix and ga4gh_keys:
-            print(f"""
+        ga4gh_prefix = ga4gh_digest.get("prefix") or "None"
+        print(f"""
 **GA4GH Digest**
 
 .. list-table::

--- a/tests/data/gnomAD/json/GnomadCAF
+++ b/tests/data/gnomAD/json/GnomadCAF
@@ -4,32 +4,6 @@
    "title": "GnomadCAF",
    "type": "object",
    "$defs": {
-      "GrpMaxFAF95": {
-         "description": "The group maximum filtering allele frequency at 95% CI",
-         "protectedClassOf": "GnomadCAF",
-         "type": "object",
-         "maturity": "draft",
-         "properties": {
-            "frequency": {
-               "type": "number"
-            },
-            "confidenceInterval": {
-               "type": "number",
-               "const": 0.95,
-               "default": 0.95
-            },
-            "groupId": {
-               "type": "string",
-               "description": "The genetic ancestry group from which the max frequency was calculated."
-            }
-         },
-         "required": [
-            "confidenceInterval",
-            "frequency",
-            "groupId"
-         ],
-         "additionalProperties": false
-      },
       "GnomadCafProperties": {
          "description": "Additional properties specific to the gnomAD CAF model.",
          "protectedClassOf": "GnomadCAF",
@@ -101,6 +75,32 @@
             }
          },
          "required": []
+      },
+      "GrpMaxFAF95": {
+         "description": "The group maximum filtering allele frequency at 95% CI",
+         "protectedClassOf": "GnomadCAF",
+         "type": "object",
+         "maturity": "draft",
+         "properties": {
+            "frequency": {
+               "type": "number"
+            },
+            "confidenceInterval": {
+               "type": "number",
+               "const": 0.95,
+               "default": 0.95
+            },
+            "groupId": {
+               "type": "string",
+               "description": "The genetic ancestry group from which the max frequency was calculated."
+            }
+         },
+         "required": [
+            "confidenceInterval",
+            "frequency",
+            "groupId"
+         ],
+         "additionalProperties": false
       }
    },
    "maturity": "draft",

--- a/tests/data/vrs/def/Adjacency.rst
+++ b/tests/data/vrs/def/Adjacency.rst
@@ -1,12 +1,27 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
 The `Adjacency` class can represent either the termination of a sequence or the adjoining of the end of a sequence with the beginning of an adjacent sequence, potentially with an intervening linker sequence.
+
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - AJ
+       - ['adjoinedSequences', 'linker', 'type']
+
 
 **Information Model**
 
@@ -19,42 +34,61 @@ Some Adjacency attributes are inherited from :ref:`Variation`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - MUST be "Adjacency".
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - expressions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">UL</span>
       - :ref:`Expression`
       - 0..m
       - 
    *  - adjoinedSequences
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`IRI` | :ref:`Location`
       - 1..2
       - The terminal sequence or pair of adjoined sequences that defines in the adjacency.
    *  - linker
+      - 
       - :ref:`SequenceExpression`
       - 0..1
       - The sequence found between adjoined sequences.

--- a/tests/data/vrs/def/Allele.rst
+++ b/tests/data/vrs/def/Allele.rst
@@ -1,12 +1,27 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
 The state of a molecule at a :ref:`Location`.
+
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - VA
+       - ['location', 'state', 'type']
+
 
 **Information Model**
 
@@ -19,42 +34,58 @@ Some Allele attributes are inherited from :ref:`Variation`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - MUST be "Allele"
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - expressions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">UL</span>
       - :ref:`Expression`
       - 0..m
       - 
    *  - location
+      - 
       - :ref:`IRI` | :ref:`Location`
       - 1..1
       - The location of the Allele
    *  - state
+      - 
       - :ref:`SequenceExpression`
       - 1..1
       - An expression of the sequence state

--- a/tests/data/vrs/def/CopyNumber.rst
+++ b/tests/data/vrs/def/CopyNumber.rst
@@ -13,38 +13,53 @@ Some CopyNumber attributes are inherited from :ref:`Variation`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - 
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - expressions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">UL</span>
       - :ref:`Expression`
       - 0..m
       - 
    *  - location
+      - 
       - :ref:`IRI` | :ref:`Location`
       - 1..1
       - A location for which the number of systemic copies is described.

--- a/tests/data/vrs/def/CopyNumber.rst
+++ b/tests/data/vrs/def/CopyNumber.rst
@@ -2,6 +2,21 @@
 
 A measure of the copies of a :ref:`Location` within a system (e.g. genome, cell, etc.)
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - ['location', 'type']
+
+
 **Information Model**
 
 Some CopyNumber attributes are inherited from :ref:`Variation`.

--- a/tests/data/vrs/def/CopyNumberChange.rst
+++ b/tests/data/vrs/def/CopyNumberChange.rst
@@ -1,12 +1,27 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
 An assessment of the copy number of a :ref:`Location` or a :ref:`Gene` within a system (e.g. genome, cell, etc.) relative to a baseline ploidy.
+
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - CX
+       - ['copyChange', 'location', 'type']
+
 
 **Information Model**
 
@@ -19,42 +34,58 @@ Some CopyNumberChange attributes are inherited from :ref:`CopyNumber`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - MUST be "CopyNumberChange"
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - expressions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">UL</span>
       - :ref:`Expression`
       - 0..m
       - 
    *  - location
+      - 
       - :ref:`IRI` | :ref:`Location`
       - 1..1
       - A location for which the number of systemic copies is described.
    *  - copyChange
+      - 
       - string
       - 1..1
       - MUST be one of "efo:0030069" (complete genomic loss), "efo:0020073" (high-level loss), "efo:0030068" (low-level loss), "efo:0030067" (loss), "efo:0030064" (regional base ploidy), "efo:0030070" (gain), "efo:0030071" (low-level gain), "efo:0030072" (high-level gain).

--- a/tests/data/vrs/def/CopyNumberCount.rst
+++ b/tests/data/vrs/def/CopyNumberCount.rst
@@ -1,12 +1,27 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
 The absolute count of discrete copies of a :ref:`Location` or :ref:`Gene`, within a system (e.g. genome, cell, etc.).
+
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - CN
+       - ['copies', 'location', 'type']
+
 
 **Information Model**
 
@@ -19,42 +34,58 @@ Some CopyNumberCount attributes are inherited from :ref:`CopyNumber`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - MUST be "CopyNumberCount"
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - expressions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">UL</span>
       - :ref:`Expression`
       - 0..m
       - 
    *  - location
+      - 
       - :ref:`IRI` | :ref:`Location`
       - 1..1
       - A location for which the number of systemic copies is described.
    *  - copies
+      - 
       - integer | :ref:`Range`
       - 1..1
       - The integral number of copies of the subject in a system

--- a/tests/data/vrs/def/Expression.rst
+++ b/tests/data/vrs/def/Expression.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
@@ -18,18 +18,22 @@ Representation of a variation by a specified nomenclature or syntax for a Variat
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - syntax
+      - 
       - string
       - 1..1
       - 
    *  - value
+      - 
       - string
       - 1..1
       - 
    *  - syntax_version
+      - 
       - string
       - 0..1
       - 

--- a/tests/data/vrs/def/Ga4ghIdentifiableObject.rst
+++ b/tests/data/vrs/def/Ga4ghIdentifiableObject.rst
@@ -2,6 +2,21 @@
 
 A contextual value object for which a GA4GH computed identifier can be created.
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - ['type']
+
+
 **Information Model**
 
 Some Ga4ghIdentifiableObject attributes are inherited from :ref:`gks.core:Entity`.

--- a/tests/data/vrs/def/Ga4ghIdentifiableObject.rst
+++ b/tests/data/vrs/def/Ga4ghIdentifiableObject.rst
@@ -13,30 +13,40 @@ Some Ga4ghIdentifiableObject attributes are inherited from :ref:`gks.core:Entity
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - 
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.

--- a/tests/data/vrs/def/Haplotype.rst
+++ b/tests/data/vrs/def/Haplotype.rst
@@ -1,12 +1,27 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
 An ordered set of co-occurring :ref:`variants <Variation>` on the same molecule.
+
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - HT
+       - ['members', 'type']
+
 
 **Information Model**
 
@@ -19,38 +34,56 @@ Some Haplotype attributes are inherited from :ref:`Variation`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - MUST be "Haplotype"
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - expressions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">UL</span>
       - :ref:`Expression`
       - 0..m
       - 
    *  - members
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Adjacency` | :ref:`Allele` | :ref:`IRI`
       - 2..m
       - A list of :ref:`Alleles <Allele>` and :ref:`Adjacencies <Adjacency>` that comprise a Haplotype.  Members must share the same reference sequence as adjacent members. Alleles should not have overlapping or adjacent coordinates with neighboring Alleles. Neighboring alleles should be ordered  by ascending coordinates, unless represented on a DNA inversion (following an Adjacency with  end-defined adjoinedSequences), in which case they should be ordered in descending coordinates.  Sequence references MUST be consistent for all members between and including the end of one  Adjacency and the beginning of another.

--- a/tests/data/vrs/def/LengthExpression.rst
+++ b/tests/data/vrs/def/LengthExpression.rst
@@ -8,6 +8,21 @@
 
 A sequence expressed only by its length.
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - ['length', 'type']
+
+
 **Information Model**
 
 Some LengthExpression attributes are inherited from :ref:`SequenceExpression`.

--- a/tests/data/vrs/def/LengthExpression.rst
+++ b/tests/data/vrs/def/LengthExpression.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
@@ -19,30 +19,40 @@ Some LengthExpression attributes are inherited from :ref:`SequenceExpression`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 1..1
       - MUST be "LengthExpression"
    *  - length
+      - 
       - :ref:`Range` | integer
       - 0..1
       - 

--- a/tests/data/vrs/def/LiteralSequenceExpression.rst
+++ b/tests/data/vrs/def/LiteralSequenceExpression.rst
@@ -8,6 +8,21 @@
 
 An explicit expression of a Sequence.
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - ['sequence', 'type']
+
+
 **Information Model**
 
 Some LiteralSequenceExpression attributes are inherited from :ref:`SequenceExpression`.

--- a/tests/data/vrs/def/LiteralSequenceExpression.rst
+++ b/tests/data/vrs/def/LiteralSequenceExpression.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
@@ -19,30 +19,40 @@ Some LiteralSequenceExpression attributes are inherited from :ref:`SequenceExpre
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 1..1
       - MUST be "LiteralSequenceExpression"
    *  - sequence
+      - 
       - :ref:`SequenceString`
       - 1..1
       - the literal sequence

--- a/tests/data/vrs/def/Range.rst
+++ b/tests/data/vrs/def/Range.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 

--- a/tests/data/vrs/def/ReferenceLengthExpression.rst
+++ b/tests/data/vrs/def/ReferenceLengthExpression.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
@@ -19,38 +19,50 @@ Some ReferenceLengthExpression attributes are inherited from :ref:`SequenceExpre
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 1..1
       - MUST be "ReferenceLengthExpression"
    *  - length
+      - 
       - integer | :ref:`Range`
       - 1..1
       - The number of residues in the expressed sequence.
    *  - sequence
+      - 
       - :ref:`SequenceString`
       - 0..1
       - the :ref:`Sequence` encoded by the Reference Length Expression.
    *  - repeatSubunitLength
+      - 
       - integer
       - 1..1
       - The number of residues in the repeat subunit.

--- a/tests/data/vrs/def/ReferenceLengthExpression.rst
+++ b/tests/data/vrs/def/ReferenceLengthExpression.rst
@@ -8,6 +8,21 @@
 
 An expression of a length of a sequence from a repeating reference.
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - ['length', 'repeatSubunitLength', 'type']
+
+
 **Information Model**
 
 Some ReferenceLengthExpression attributes are inherited from :ref:`SequenceExpression`.

--- a/tests/data/vrs/def/Residue.rst
+++ b/tests/data/vrs/def/Residue.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 

--- a/tests/data/vrs/def/SequenceExpression.rst
+++ b/tests/data/vrs/def/SequenceExpression.rst
@@ -2,6 +2,21 @@
 
 An expression describing a :ref:`Sequence`.
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - ['type']
+
+
 **Information Model**
 
 Some SequenceExpression attributes are inherited from :ref:`gks.core:Entity`.

--- a/tests/data/vrs/def/SequenceExpression.rst
+++ b/tests/data/vrs/def/SequenceExpression.rst
@@ -13,26 +13,35 @@ Some SequenceExpression attributes are inherited from :ref:`gks.core:Entity`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 1..1
       - The SequenceExpression class type. MUST match child class type.

--- a/tests/data/vrs/def/SequenceLocation.rst
+++ b/tests/data/vrs/def/SequenceLocation.rst
@@ -1,12 +1,27 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
 A :ref:`Location` defined by an interval on a referenced :ref:`Sequence`.
+
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - SL
+       - ['end', 'sequenceReference', 'start', 'type']
+
 
 **Information Model**
 
@@ -19,42 +34,55 @@ Some SequenceLocation attributes are inherited from :ref:`Ga4ghIdentifiableObjec
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - MUST be "SequenceLocation"
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - sequenceReference
+      - 
       - :ref:`IRI` | :ref:`SequenceReference`
       - 0..1
       - A :ref:`SequenceReference`.
    *  - start
+      - 
       - integer | :ref:`Range`
       - 0..1
       - The start coordinate or range of the SequenceLocation. The minimum value of this coordinate or range is 0. MUST represent a coordinate or range less than or equal to the value of `end`.
    *  - end
+      - 
       - integer | :ref:`Range`
       - 0..1
       - The end coordinate or range of the SequenceLocation. The minimum value of this coordinate or range is 0. MUST represent a coordinate or range greater than or equal to the value of `start`.

--- a/tests/data/vrs/def/SequenceReference.rst
+++ b/tests/data/vrs/def/SequenceReference.rst
@@ -8,6 +8,21 @@
 
 A sequence of nucleic or amino acid character codes.
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - []
+
+
 **Information Model**
 
 Some SequenceReference attributes are inherited from :ref:`gks.core:Entity`.

--- a/tests/data/vrs/def/SequenceReference.rst
+++ b/tests/data/vrs/def/SequenceReference.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 
@@ -19,34 +19,45 @@ Some SequenceReference attributes are inherited from :ref:`gks.core:Entity`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - 
    *  - refgetAccession
+      - 
       - string
       - 1..1
       - A `GA4GH RefGet <http://samtools.github.io/hts-specs/refget.html>` identifier for the referenced sequence,  using the sha512t24u digest.
    *  - residueAlphabet
+      - 
       - string
       - 0..1
       - The interpretation of the character codes referred to by the refget accession, where "aa" specifies an amino acid character set, and "na" specifies a nucleic acid character set.

--- a/tests/data/vrs/def/SequenceString.rst
+++ b/tests/data/vrs/def/SequenceString.rst
@@ -1,8 +1,8 @@
 
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
+
                     
 **Computational Definition**
 

--- a/tests/data/vrs/def/Variation.rst
+++ b/tests/data/vrs/def/Variation.rst
@@ -2,6 +2,21 @@
 
 A representation of the state of one or more biomolecules.
 
+**GA4GH Digest**
+
+.. list-table::
+    :class: clean-wrap
+    :header-rows: 1
+    :align: left
+    :widths: auto
+
+    *  - Prefix
+       - Keys
+
+    *  - None
+       - ['type']
+
+
 **Information Model**
 
 Some Variation attributes are inherited from :ref:`Ga4ghIdentifiableObject`.

--- a/tests/data/vrs/def/Variation.rst
+++ b/tests/data/vrs/def/Variation.rst
@@ -13,34 +13,48 @@ Some Variation attributes are inherited from :ref:`Ga4ghIdentifiableObject`.
    :widths: auto
 
    *  - Field
+      - Flags
       - Type
       - Limits
       - Description
    *  - id
+      - 
       - string
       - 0..1
       - The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is  unique within a given system. The identified entity may have a different 'id' in a different  system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
    *  - label
+      - 
       - string
       - 0..1
       - A primary label for the entity.
    *  - description
+      - 
       - string
       - 0..1
       - A free-text description of the entity.
    *  - extensions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">OL</span>
       - :ref:`Extension`
       - 0..m
       - 
    *  - type
+      - 
       - string
       - 0..1
       - 
    *  - digest
+      - 
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
    *  - expressions
+      - 
+                        .. raw:: html
+
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: block; margin-bottom: 5px;">UL</span>
       - :ref:`Expression`
       - 0..m
       - 


### PR DESCRIPTION
close #26

* Add GA4GH Digest table if prefix or keys are provided
* Add Flags column for property level maturity status + ordered property in arrays
<img width="540" alt="Screenshot 2024-11-04 at 16 34 12" src="https://github.com/user-attachments/assets/581e0c8b-a874-44cb-ba9f-27a45e8e9b2d">
