### PR TITLE
fix: remove new lines + extra spaces in maturity template

### DIFF
--- a/src/templates/maturity
+++ b/src/templates/maturity
@@ -1,4 +1,4 @@
-.. {{ info }}:: This data class is at a **{{ maturity_level }}** maturity level and may change
-    {{ modifier }} in future releases. Maturity levels are described in
-    the :ref:`maturity-model`.
+.. {{ info }}:: This data class is at a **{{ maturity_level }}** maturity level and may \
+    change{{ ' ' if modifier else '' }}{{ modifier }} in future releases. Maturity \
+    levels are described in the :ref:`maturity-model`.
 


### PR DESCRIPTION
close #33

I changed the maturity level locally. I think the references should resolve in upstream spec docs

![Screenshot 2024-11-08 at 08 11 32](https://github.com/user-attachments/assets/978753b0-5ae6-4df2-8fa0-2f57275923d4)
