### PR TITLE
fix: ensure newlines at EOF + remove trailing whitespace in RST tables

### DIFF
--- a/src/ga4gh/gks/metaschema/scripts/source2splitjs.py
+++ b/src/ga4gh/gks/metaschema/scripts/source2splitjs.py
@@ -106,6 +106,7 @@ def split_defs_to_js(root_proc: YamlSchemaProcessor, mode: str = "json") -> None
         out_doc["$id"] = root_proc.get_class_uri(cls, mode)
         with open(target_path, "w") as f:
             json.dump(out_doc, f, indent=3, sort_keys=False)
+            f.write("\n")
 
 
 def cli():

--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -215,15 +215,16 @@ def main(proc_schema: YamlSchemaProcessor) -> None:
                 file=f,
             )
             for class_property_name, class_property_attributes in class_definition[p].items():
-                print(
-                    f"""\
+                class_definition_formatted = f"""\
    *  - {class_property_name}
       - {resolve_flags(class_property_attributes)}
       - {resolve_type(class_property_attributes)}
       - {resolve_cardinality(class_property_name, class_property_attributes, class_definition)}
-      - {class_property_attributes.get('description', '')}""",
-                    file=f,
+      - {class_property_attributes.get('description', '')}"""
+                class_definition_formatted = "\n".join(
+                    line.rstrip() for line in class_definition_formatted.splitlines()
                 )
+                print(class_definition_formatted, file=f)
 
 
 def cli():


### PR DESCRIPTION
(low priority)

There are a few places where the metaschema processor does things that violate basic formatting/precommit check type things. These create a bunch of unnecessary git diffs every time you rebuild a schema. This PR ensures that:

* newline character at EOF (https://gist.github.com/camh-/1bebfcff1b0f814e9b191edc60d5206b)
* removes trailing whitespaces from the class definition RST tables