### PR TITLE
fix: don't generate info tables for property-less classes

### DIFF
--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -199,9 +199,10 @@ def main(proc_schema: YamlSchemaProcessor) -> None:
 
             add_ga4gh_digest(class_definition, f)
 
-            print("\n**Information Model**", file=f)
-            print(
-                f"""
+            if class_definition[p].items():
+                print("\n**Information Model**", file=f)
+                print(
+                    f"""
 {inheritance}
 .. list-table::
    :class: clean-wrap
@@ -214,19 +215,19 @@ def main(proc_schema: YamlSchemaProcessor) -> None:
       - Type
       - Limits
       - Description""",
-                file=f,
-            )
-            for class_property_name, class_property_attributes in class_definition[p].items():
-                class_definition_formatted = f"""\
+                    file=f,
+                )
+                for class_property_name, class_property_attributes in class_definition[p].items():
+                    class_definition_formatted = f"""\
    *  - {class_property_name}
       - {resolve_flags(class_property_attributes)}
       - {resolve_type(class_property_attributes)}
       - {resolve_cardinality(class_property_name, class_property_attributes, class_definition)}
       - {class_property_attributes.get("description", "")}"""
-                class_definition_formatted = "\n".join(
-                    line.rstrip() for line in class_definition_formatted.splitlines()
-                )
-                print(class_definition_formatted, file=f)
+                    class_definition_formatted = "\n".join(
+                        line.rstrip() for line in class_definition_formatted.splitlines()
+                    )
+                    print(class_definition_formatted, file=f)
 
 
 def cli():

--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -199,8 +199,8 @@ def main(proc_schema: YamlSchemaProcessor) -> None:
 
             add_ga4gh_digest(class_definition, f)
 
+            print("\n**Information Model**", file=f)
             if class_definition[p].items():
-                print("\n**Information Model**", file=f)
                 print(
                     f"""
 {inheritance}


### PR DESCRIPTION
close #45 <- more detail here

* Don't generate the "Information model" table for classes where the table is empty. This fixes build warnings that pop up when you generate VA-Spec and Cat-VRS docs (see eg all the "list-table" instances here https://github.com/ga4gh/va-spec/issues/382#issuecomment-3589720741 )
* I tested by regenerating schema artifacts in VRS, Cat-VRS, and VA-Spec. No changes in the former, and in the latter it just removed instances of empty tables. I did not remove the "Information Model" header because the Cat-VRS docs manually provide some additional text under it (but maybe this should be something they supply themselves if they want to include their own text).

## Notes
* Are these classes supposed to be "pass-throughs"? If so, then `YamlSchemaProcessor.class_is_passthrough()` should be updated instead