### PR TITLE
ci: remove get_branch job for pypi release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,25 +4,9 @@ on:
     tags:
       - "*.*.**"
 jobs:
-  get_branch:
-    runs-on: ubuntu-latest
-    outputs:
-      branch_name: ${{ steps.get_branch_name.outputs.name }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Get branch name
-        id: get_branch_name
-        run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
-          branch=$(echo "$raw" | grep "origin/main" | grep -v "HEAD" | sed "s|origin/||" | xargs)
-          echo "name=$branch" >> "$GITHUB_OUTPUT"
   build:
     name: Build distribution
     runs-on: ubuntu-latest
-    needs: get_branch
-    if: needs.get_branch.outputs.branch_name == 'main'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
I have several draft PRs (#53, #54, #55, #56) that I plan to merge in to the `release/0.4.0` branch and create alpha releases on that branch before merging into main (just in case we need to make patch releases)